### PR TITLE
Added NK_DEKF17, NK_DT12 and US_CCF12.json

### DIFF
--- a/static/mmci-cli/models/NK_DEFK17/NK_DEFK17.json
+++ b/static/mmci-cli/models/NK_DEFK17/NK_DEFK17.json
@@ -1,0 +1,327 @@
+{
+  "$schema": "model",
+  "name": "NK_DEFK17",
+  "capabilities": {
+    "fiscal_shock": true,
+    "inflation": true,
+    "interest": true,
+    "mp_shock": true,
+    "output": true,
+    "outputgap": true,
+    "rules": [
+      3,
+      8,
+      9,
+      11
+    ],
+    "unconditional_variances": true
+  },
+  "description": {
+    "ac_ref": "Del Negro et al. (2017)",
+    "paper_title": "The Great Escape? A Quantitative Evaluation of the Fed's Liquidity Facilities",
+    "journal": "American Economic Review 107 (3), pp. 824-857",
+    "replicants_name": "S. Girstmair and A. Yambolov",
+    "pub_date": "2017",
+    "keywords": [],
+    "description": "",
+    "category": "Calibrated model",
+    "authors": [
+      "Del Negro, Marco",
+      "Eggertsson, Gauti",
+      "Ferrero, Andrea",
+      "Kiyotaki, Nobuhiro"
+    ]
+  },
+  "msr": null,
+  "variabledim": 1,
+  "al": false,
+  "shocks": [
+    {
+      "name": "e_a",
+      "text": "e_a"
+    },
+    {
+      "name": "e_phi",
+      "text": "e_phi"
+    },
+    {
+      "name": "fiscal_",
+      "text": "fiscal_"
+    },
+    {
+      "name": "interest_",
+      "text": "interest_"
+    }
+  ],
+  "al_info": null,
+  "variables": [
+    {
+      "name": "A",
+      "text": "A"
+    },
+    {
+      "name": "G",
+      "text": "G"
+    },
+    {
+      "name": "e_g",
+      "text": "e_g"
+    },    
+    {
+      "name": "C",
+      "text": "C"
+    },
+    {
+      "name": "Inv",
+      "text": "Inv"
+    },
+    {
+      "name": "S_Inv",
+      "text": "S_Inv"
+    },
+    {
+      "name": "dS_Inv",
+      "text": "dS_Inv"
+    },
+    {
+      "name": "H",
+      "text": "H"
+    },
+    {
+      "name": "Y",
+      "text": "Y"
+    },
+    {
+      "name": "fispol",
+      "text": "fispol"
+    },
+    {
+      "name": "tau",
+      "text": "tau"
+    },
+    {
+      "name": "K",
+      "text": "K"
+    },
+    {
+      "name": "N",
+      "text": "N"
+    },
+    {
+      "name": "inflation",
+      "text": "inflation"
+    },
+    {
+      "name": "inflationq",
+      "text": "inflationq"
+    },
+    {
+      "name": "interest",
+      "text": "interest"
+    },
+    {
+      "name": "Ng",
+      "text": "Ng"
+    },
+    {
+      "name": "LY",
+      "text": "LY"
+    },
+    {
+      "name": "QK",
+      "text": "QK"
+    },
+    {
+      "name": "GDP",
+      "text": "GDP"
+    },
+    {
+      "name": "output",
+      "text": "output"
+    },
+    {
+      "name": "outputgap",
+      "text": "outputgap"
+    },
+    {
+      "name": "R",
+      "text": "R"
+    },
+    {
+      "name": "Q",
+      "text": "Q"
+    },
+    {
+      "name": "pI",
+      "text": "pI"
+    },
+    {
+      "name": "RK",
+      "text": "RK"
+    },
+    {
+      "name": "rK",
+      "text": "rK"
+    },
+    {
+      "name": "rr",
+      "text": "rr"
+    },
+    {
+      "name": "ERQ",
+      "text": "ERQ"
+    },
+    {
+      "name": "w",
+      "text": "w"
+    },
+    {
+      "name": "infl_w",
+      "text": "infl_w"
+    },
+    {
+      "name": "X1w",
+      "text": "X1w"
+    },
+    {
+      "name": "X2w",
+      "text": "X2w"
+    },
+    {
+      "name": "mc",
+      "text": "mc"
+    },
+    {
+      "name": "infl",
+      "text": "infl"
+    },
+    {
+      "name": "X1p",
+      "text": "X1p"
+    },
+    {
+      "name": "X2p",
+      "text": "X2p"
+    },
+    {
+      "name": "Delta_p",
+      "text": "Delta_p"
+    },
+    {
+      "name": "CY",
+      "text": "CY"
+    },
+    {
+      "name": "Spr",
+      "text": "Spr"
+    },
+    {
+      "name": "phi",
+      "text": "phi"
+    },
+    {
+      "name": "C_f",
+      "text": "C_f"
+    },
+    {
+      "name": "Inv_f",
+      "text": "Inv_f"
+    },
+    {
+      "name": "S_Inv_f",
+      "text": "S_Inv_f"
+    },
+    {
+      "name": "dS_Inv_f",
+      "text": "dS_Inv_f"
+    },
+    {
+      "name": "H_f",
+      "text": "H_f"
+    },
+    {
+      "name": "Y_f",
+      "text": "Y_f"
+    },
+    {
+      "name": "tau_f",
+      "text": "tau_f"
+    },
+    {
+      "name": "K_f",
+      "text": "K_f"
+    },
+    {
+      "name": "N_f",
+      "text": "N_f"
+    },
+    {
+      "name": "Ng_f",
+      "text": "Ng_f"
+    },
+    {
+      "name": "LY_f",
+      "text": "LY_f"
+    },
+    {
+      "name": "QK_f",
+      "text": "QK_f"
+    },
+    {
+      "name": "GDP_f",
+      "text": "GDP_f"
+    },
+    {
+      "name": "R_f",
+      "text": "R_f"
+    },
+    {
+      "name": "R0_f",
+      "text": "R0_f"
+    },    
+    {
+      "name": "Q_f",
+      "text": "Q_f"
+    },
+    {
+      "name": "pI_f",
+      "text": "pI_f"
+    },
+    {
+      "name": "RK_f",
+      "text": "RK_f"
+    },
+    {
+      "name": "rK_f",
+      "text": "rK_f"
+    },
+    {
+      "name": "ERQ_f",
+      "text": "ERQ_f"
+    },
+    {
+      "name": "w_f",
+      "text": "w_f"
+    },
+    {
+      "name": "infl_w",
+      "text": "infl_w"
+    },
+    {
+      "name": "mc_f",
+      "text": "mc_f"
+    },
+    {
+      "name": "CY_f",
+      "text": "CY_f"
+    },
+    {
+      "name": "Spr_f",
+      "text": "Spr_f"
+    },
+    {
+      "name": "phi_f",
+      "text": "phi_f"    
+    }
+  ]
+}

--- a/static/mmci-cli/models/NK_DEFK17/NK_DEFK17.mod
+++ b/static/mmci-cli/models/NK_DEFK17/NK_DEFK17.mod
@@ -1,0 +1,427 @@
+var 
+
+// Model Variables
+A G e_g
+C Inv S_Inv dS_Inv H Y tau K N Ng LY QK GDP
+R Q pI RK rK rr ERQ w infl_w X1w X2w mc infl X1p X2p Delta_p CY Spr phi
+
+// Flexible price variables
+C_f Inv_f S_Inv_f dS_Inv_f H_f Y_f tau_f K_f N_f Ng_f LY_f QK_f GDP_f
+R_f R0_f Q_f pI_f RK_f rK_f ERQ_f w_f mc_f CY_f Spr_f phi_f
+
+
+//**************************************************************************
+// Modelbase Variables                                                   //*
+        interest inflation inflationq outputgap output                   //*
+        fispol                                                           //*   
+        ;                                                                //*
+//**************************************************************************
+
+varexo              
+e_a e_phi
+//**************************************************************************
+// Modelbase Shocks                                                      //*       
+       interest_                                                         //*
+       fiscal_                                                           //*   
+       ;                                                                 //*
+//**************************************************************************
+
+
+parameters 
+//************************************************************************** 
+// Modelbase Parameters                                                  //*
+                                                                         //*
+        cofintintb1 cofintintb2 cofintintb3 cofintintb4                  //*
+        cofintinf0 cofintinfb1 cofintinfb2 cofintinfb3 cofintinfb4       //*
+        cofintinff1 cofintinff2 cofintinff3 cofintinff4                  //*
+        cofintout cofintoutb1 cofintoutb2 cofintoutb3 cofintoutb4        //*
+        cofintoutf1 cofintoutf2 cofintoutf3 cofintoutf4                  //*
+        cofintoutp cofintoutpb1 cofintoutpb2 cofintoutpb3 cofintoutpb4   //*
+        cofintoutpf1 cofintoutpf2 cofintoutpf3 cofintoutpf4              //*
+        std_r_ std_r_quart coffispol                                     //*
+                                                                         //*
+//**************************************************************************
+ 
+
+% Structural parameters
+rho_a rho_g G_Y
+beta sigma nu kappa theta gamma Gamma delta s0 lambda_w lambda_p xi_w xi_p
+
+% Policy rules parameters
+psi_p psi_y rho_i psi_k psi_tau rho_phi
+
+% Steady state values
+Y_ss C_ss I_ss K_ss H_ss R_ss Q_ss RK_ss rK_ss w_ss tau_ss LY_ss A_ss phi_ss
+Y_f_ss CY_ss;
+
+beta=0.99347;
+sigma=1;
+nu=1;
+theta=0.79246;
+kappa=0.009486;
+delta=0.024291;
+gamma=0.34002;
+s0=0.75;
+xi_p=0.75;
+xi_w=0.75;
+lambda_p=0.1;
+lambda_w=0.1;
+psi_p=1.5;
+psi_y=0.125;
+rho_i=0;
+psi_tau=0.1;
+
+R_ss=1.0055;
+A_ss=1;
+phi_ss=0.3092;
+LY_ss=1.6;
+Y_ss=2.6779;
+K_ss=29.2064;
+H_ss=0.90345;
+I_ss=0.70945;
+C_ss=1.9685;
+Q_ss=1.0223;
+RK_ss=0.031176;
+rK_ss=0.031176;
+CY_ss=0.0011116;
+w_ss=1.9563;
+tau_ss=0.023387;
+KY_ratio=10.9064;
+KH_ratio=32.3277;
+IY_ratio=0.26493;
+CY_ratio=0.73507;
+Gamma=0.26779;
+
+psi_k=-4.8064;
+rho_phi=0.9525;
+rho_g = 0.97;
+rho_a = 0.95;
+G_Y = 0.21;
+
+//**************************************************************************
+// Specification of Modelbase Parameters                                 //*
+                                                                         //*
+// Load Modelbase Monetary Policy Parameters                             //*
+thispath = pwd;                                                           
+cd('..');                                                                
+load policy_param.mat;                                                   
+for i=1:33                                                               
+    deep_parameter_name = M_.param_names(i,:);                           
+    eval(['M_.params(i)  = ' deep_parameter_name ' ;'])                  
+end                                                                      
+cd(thispath);   
+
+// Definition of Discretionary Fiscal Policy Parameter                   //*
+coffispol = 1;                                                           //*   
+                                                                         //*
+//**************************************************************************
+
+model;
+
+//**************************************************************************
+// Definition of Modelbase Variables in Terms of Original Model Variables //*
+
+interest   = 4*log(R/steady_state(R));                                    //*
+inflation  = log(infl)+log(infl(-1))+log(infl(-2))+log(infl(-3));         //*
+inflationq = 4*log(infl/steady_state(infl));                              //*
+outputgap  = log(Y/steady_state(Y)) - log(Y_f/steady_state(Y_f));         //*
+output     = log(Y/steady_state(Y));                                      //*
+fispol     = e_g;                                                         //*    
+//**************************************************************************
+
+
+//**************************************************************************                                                                    
+// Policy Rule                                                           //*
+                                                                         //*
+// Monetary Policy                                                       //*
+                                                                         //*
+interest =   cofintintb1*interest(-1)                                    //* 
+           + cofintintb2*interest(-2)                                    //* 
+           + cofintintb3*interest(-3)                                    //* 
+           + cofintintb4*interest(-4)                                    //* 
+           + cofintinf0*inflationq                                       //* 
+           + cofintinfb1*inflationq(-1)                                  //* 
+           + cofintinfb2*inflationq(-2)                                  //* 
+           + cofintinfb3*inflationq(-3)                                  //* 
+           + cofintinfb4*inflationq(-4)                                  //* 
+           + cofintinff1*inflationq(+1)                                  //* 
+           + cofintinff2*inflationq(+2)                                  //* 
+           + cofintinff3*inflationq(+3)                                  //* 
+           + cofintinff4*inflationq(+4)                                  //* 
+           + cofintout*outputgap 	                                     //* 
+           + cofintoutb1*outputgap(-1)                                   //* 
+           + cofintoutb2*outputgap(-2)                                   //* 
+           + cofintoutb3*outputgap(-3)                                   //* 
+           + cofintoutb4*outputgap(-4)                                   //* 
+           + cofintoutf1*outputgap(+1)                                   //* 
+           + cofintoutf2*outputgap(+2)                                   //* 
+           + cofintoutf3*outputgap(+3)                                   //* 
+           + cofintoutf4*outputgap(+4)                                   //*
+           + cofintoutp*output 	                                         //* 
+           + cofintoutpb1*output(-1)                                     //* 
+           + cofintoutpb2*output(-2)                                     //* 
+           + cofintoutpb3*output(-3)                                     //* 
+           + cofintoutpb4*output(-4)                                     //* 
+           + cofintoutpf1*output(+1)                                     //* 
+           + cofintoutpf2*output(+2)                                     //* 
+           + cofintoutpf3*output(+3)                                     //* 
+           + cofintoutpf4*output(+4)                                     //*  
+           + std_r_ *interest_;                                          //* 
+                                                                         //*
+// Discretionary Government Spending                                     //*
+                                                                         //*
+fispol = coffispol*fiscal_;                                              //*  
+//**************************************************************************
+
+// Original Model Code:
+// 1) Euler equation for bonds C
+C^(-sigma) = beta * (C(+1)^(-sigma)) * rr * ( 1 + kappa * (Q(+1) - pI(+1)) / (pI(+1) - theta * Q(+1)) );
+
+// 2) Euler equation for equity Q
+C^(-sigma) = beta *  (C(+1)^(-sigma)) * ( (RK(+1) + (1 - delta) * Q(+1)) / Q ) *
+(1 + kappa * (Q(+1) - pI(+1)) * (RK(+1) + phi(+1) * (1 - delta) * Q(+1)) / ( (pI(+1) - theta * Q(+1)) * (RK(+1) + (1 - delta) * Q(+1)) ) ) ;
+
+// 3) Investment equation Inv
+(pI - theta * Q) * Inv = kappa * ( (RK + phi * (1 - delta) * Q) * N(-1) + R(-1) * LY(-1) * Y(-1) / infl - tau ); 
+
+// 4) Price of investment pI
+pI = 1 + S_Inv + dS_Inv * (Inv / I_ss);
+// + beta * ((C(+1) / C)^(-sigma)) * dS_Inv(+1) * (Inv(+1) / Inv)^2;
+
+// 5) Investment adjustment cost function S_Inv
+S_Inv = s0 * (Inv / I_ss - 1)^2 / 2;
+
+// 6) First derivative of investment adjustment cost function dS_Inv
+dS_Inv = s0 * (Inv / I_ss - 1);
+
+// 7) Production function Y
+Y * Delta_p = A * (K(-1)^gamma) * (H^(1-gamma)) - Gamma;
+
+// 8) MPK
+rK = gamma * mc * A * (H / K(-1))^(1-gamma);
+
+// 9) MPL
+w = (1 - gamma) * mc * A * (K(-1) / H)^gamma;
+
+// 10) Rental rate RK
+RK * K(-1) =  Y - w * H + (pI - (1 + S_Inv)) * Inv;
+
+// 11) Market clearing condition for capital N
+K = N + Ng;
+
+// 12) Law of motion of capital K
+K = (1 - delta) * K(-1) + Inv; 
+
+// 13) Price Phillips curve infl
+X1p = X2p * ( (1 - xi_p * infl^(1 / lambda_p)) / (1 - xi_p) )^(- lambda_p);
+
+// 14) PDV of real marginal costs X1p
+X1p = (1 + lambda_p) * (C^(-sigma)) * Y * mc + beta * xi_p * ( infl(+1)^((1 + lambda_p) / lambda_p) ) * X1p(+1);
+
+// 15) PDV of real marginal revenues X2p
+X2p = (C^(-sigma)) * Y + beta * xi_p * ( infl(+1)^(1 / lambda_p) ) * X2p(+1);
+
+// 16) Wage Phillips curve infl_w
+X1w = X2w * ( (1 - xi_w * infl_w^(1 / lambda_w)) / (1 - xi_w) )^(- (lambda_w + (1 + lambda_w) * nu));
+
+// 17) PDV of marginal disutility of work X1w
+X1w = (1 + lambda_w) * H^(1+nu) + beta * xi_w * ( infl_w(+1)^((1 + lambda_w) * (1 + nu) / lambda_w) ) * X1w(+1);
+
+// 18) PDV of real wage X2w
+X2w = (C^(-sigma)) * w * H + beta * xi_w * ( infl_w(+1)^(1 / lambda_w) ) * X2w(+1);
+
+// 19) Relation between real wage and inflation rates
+w * infl = w(-1) * infl_w;
+
+// 20) Price dispersion Delta_p
+Delta_p = xi_p * Delta_p(-1) * infl^((1 + lambda_p) / lambda_p) + (1 - xi_p) * ( (1 - xi_p * infl^(1 / lambda_p)) / (1 - xi_p) )^(1 + lambda_p);
+
+// 21) Taylor rule R
+// R = (R_ss^(1-rho_i)) * (R(-1)^rho_i) * (infl^psi_p) * ((Y/Y_ss)^psi_y);
+
+// 22) Liquidity intervention Ng
+Ng = psi_k * (phi - phi_ss);
+
+// 23) Tax rule tau
+tau = tau_ss + psi_tau * (R(-1) * LY(-1) * Y(-1) / infl - R_ss * LY_ss * Y_ss - Q * Ng(-1));
+
+// 24) Government budget constraint LY
+Q * Ng + R(-1) * LY(-1) * Y(-1) / infl = tau - G + (RK + (1 - delta) * Q) * Ng(-1) + LY * Y;
+
+// 25) Resource constraint rK
+Y = C + (1 + S_Inv) * Inv + G; 
+
+// 26) Real rate
+rr = R / infl(+1);
+
+// 27) Expected return on illiquid asset
+ERQ = (RK(+1) + (1 - delta) * Q(+1)) / Q;
+ 
+// 28) Spread equity-bonds
+Spr = ERQ - rr;
+ 
+// 29) Convenience yield
+CY = kappa * (Q(+1) - pI(+1)) / (pI(+1) - theta * Q(+1));
+
+// 30) Value of capital
+QK = Q * K(-1);
+
+// 31) GDP
+GDP = C + pI * Inv;
+
+// 32) Borrowing constraint shock phi
+phi = (1 - rho_phi) * phi_ss + rho_phi * phi(-1) + e_phi;
+
+A = (1-rho_a)*A_ss + rho_a * A(-1) + e_a;
+
+G = (1-rho_g)*(G_Y*steady_state(Y)) + rho_g * G(-1) + e_g;
+
+// Flexible price model
+// 1) Euler equation for bonds C_f
+C_f^(-sigma) = beta * (C_f(+1)^(-sigma)) * R_f * ( 1 + kappa * (Q_f(+1) - pI_f(+1)) / (pI_f(+1) - theta * Q_f(+1)) );
+
+// 2) Euler equation for equity Q_f
+C_f^(-sigma) = beta * (C_f(+1)^(-sigma)) * ( (RK_f(+1) + (1 - delta) * Q_f(+1)) / Q_f ) *
+(1 + kappa * (Q_f(+1) - pI_f(+1)) * (RK_f(+1) + phi_f(+1) * (1 - delta) * Q_f(+1)) / ( (pI_f(+1) - theta * Q_f(+1)) * (RK_f(+1) + (1 - delta) * Q_f(+1)) ) ) ;
+
+// 3) Investment equation Inv_f
+(pI_f - theta * Q_f) * Inv_f = kappa * ( (RK_f + phi_f * (1 - delta) * Q_f) * N_f(-1) + R_f(-1) * LY_f(-1) * Y_f(-1) - tau_f ); 
+
+// 4) Price of investment pI_f
+pI_f = 1 + S_Inv_f + dS_Inv_f * (Inv_f / I_ss);
+// + beta * ((C_f(+1) / C_f)^(-sigma)) * dS_Inv_f(+1) * (Inv_f(+1) / Inv_f)^2;
+
+// 5) Investment adjustment cost function S_Inv_f
+S_Inv_f = s0 * (Inv_f / I_ss - 1)^2 / 2;
+
+// 6) First derivative of investment adjustment cost function dS_Inv_f
+dS_Inv_f = s0 * (Inv_f / I_ss - 1);
+
+// 7) Production function Y_f
+Y_f = A * (K_f(-1)^gamma) * (H_f^(1-gamma)) - Gamma;
+
+// 8) MPK
+rK_f = gamma * mc_f * A * (H_f / K_f(-1))^(1-gamma);
+
+// 9) MPL
+w_f = (1 - gamma) * mc_f * A * (K_f(-1) / H_f)^gamma;
+
+// 10) Rental rate RK_f
+RK_f * K_f(-1) =  Y_f - w_f * H_f + (pI_f - (1 + S_Inv_f)) * Inv_f;
+
+// 11) Market clearing condition for capital N_f
+K_f = N_f + Ng_f;
+
+// 12) Law of motion of capital K_f
+K_f = (1 - delta) * K_f(-1) + Inv_f; 
+
+// 13) Price mark-up
+(1 + lambda_p) * mc_f = 1;
+
+// 14) Wage mark-up
+(1 + lambda_w) * H_f^nu = (C_f^(-sigma)) * w_f;
+
+// 15) Liquidity intervention Ng_f
+Ng_f = psi_k * (phi_f - phi_ss);
+
+// 16) Tax rule tau_f
+tau_f = tau_ss + psi_tau * (R_f(-1) * LY_f(-1) * Y_f(-1) - R_ss * LY_ss * Y_ss - Q_f * Ng_f(-1));
+
+// 17) Government budget constraint LY_f
+Q_f * Ng_f + R_f(-1) * LY_f(-1) * Y_f(-1) = tau_f - G + (RK_f + (1 - delta) * Q_f) * Ng_f(-1) + LY_f * Y_f;
+
+// 18) Resource constraint rK
+Y_f = C_f + (1 + S_Inv_f) * Inv_f + G; 
+
+// 19) Expected return on illiquid asset
+ERQ_f = (RK_f(+1) + (1 - delta) * Q_f(+1)) / Q_f;
+ 
+// 20) Spread equity-bonds
+Spr_f = ERQ_f - R_f;
+ 
+// 21) Convenience yield
+CY_f = kappa * (Q_f(+1) - pI_f(+1)) / (pI_f(+1) - theta * Q_f(+1));
+
+// 22) Value of capital
+QK_f = Q_f * K_f(-1);
+
+// 23) GDP
+GDP_f = C_f + pI_f * Inv_f;
+
+// 24) Return on illiquid security
+C_f^(-sigma) = beta * (C_f(+1)^(-sigma) * R0_f);
+
+// 25) Borrowing constraint shock phi_f
+phi_f = (1 - rho_phi) * phi_ss + rho_phi * phi_f(-1) + e_phi;
+
+end;
+
+initval;
+e_g = 0;
+G = G_Y*Y_ss;
+C       = C_ss;
+Inv     = I_ss;
+S_Inv   = 0;
+dS_Inv  = 0;
+H       = H_ss;
+Y       = Y_ss; 
+LY      = LY_ss;
+tau     = tau_ss;
+K       = K_ss;
+N       = K_ss;
+Ng      = 0;
+R       = R_ss;
+rr      = R_ss;
+ERQ     = RK_ss / Q_ss + (1 - delta);
+Spr     = ERQ - rr;
+Q       = Q_ss;
+pI      = 1;
+RK      = RK_ss;
+rK      = rK_ss;
+CY      = CY_ss;
+w       = w_ss;
+infl_w  = 1;
+X1w     = (1 + lambda_w) * H_ss^(1+nu) / (1 - beta * xi_w);
+X2w     = (C_ss^(-sigma)) * w_ss * H_ss / (1 - beta * xi_w);
+mc      = 1 / (1 + lambda_p);
+infl    = 1;
+X1p     = (C_ss^(-sigma)) * Y_ss / (1 - beta * xi_p);
+X2p     = (C_ss^(-sigma)) * Y_ss / (1 - beta * xi_p);
+Delta_p = 1;
+phi     = phi_ss;
+
+
+C_f       = C_ss;
+Inv_f     = I_ss;
+S_Inv_f   = 0;
+dS_Inv_f  = 0;
+H_f       = H_ss;
+Y_f       = Y_ss; 
+LY_f      = LY_ss;
+tau_f     = tau_ss;
+K_f       = K_ss;
+N_f       = K_ss;
+Ng_f      = 0;
+R_f       = R_ss;
+R0_f      = R_ss * (1 + CY_ss);
+ERQ_f     = RK_ss / Q_ss + (1 - delta);
+Spr_f     = ERQ_f - R_f;
+Q_f       = Q_ss;
+pI_f      = 1;
+RK_f      = RK_ss;
+rK_f      = rK_ss;
+CY_f      = CY_ss;
+w_f       = w_ss;
+mc_f      = 1 / (1 + lambda_p);
+phi_f     = phi_ss;
+
+QK = Q_ss * K_ss;
+QK_f = Q_ss * K_ss;
+GDP = C_ss +  I_ss;
+GDP_f = C_ss +  I_ss;
+
+end;
+
+steady(solve_algo=3);
+resid(1);
+check;

--- a/static/mmci-cli/models/NK_DT12/NK_DT12.json
+++ b/static/mmci-cli/models/NK_DT12/NK_DT12.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "model",
+  "name": "NK_DT12",
+  "capabilities": {
+    "fiscal_shock": false,
+    "inflation": true,
+    "interest": true,
+    "mp_shock": true,
+    "output": true,
+    "outputgap": true,
+    "rules": [
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11
+    ],
+    "unconditional_variances": true
+  },
+  "description": {
+    "ac_ref": "De Fiore & Tristani (2012)",
+    "paper_title": "Optimal Monetary Policy in a Model of the Credit Channel",
+    "journal": "The Economic Journal 123(571), pp. 906-931",
+    "replicants_name": "C. Mücke and J. Binder",
+    "pub_date": "2012",
+    "keywords": [],
+    "description": "",
+    "category": "Calibrated model",
+    "authors": [
+      "De Fiore, Fiorella",
+      "Tristani, Oreste"
+    ]
+  },
+  "msr": null,
+  "variabledim": 1,
+  "al": false,
+  "shocks": [
+    {
+      "name": "epsA",
+      "text": "epsA"
+    },
+    {
+      "name": "epsmu",
+      "text": "epsmu"
+    },
+    {
+      "name": "epstau",
+      "text": "epstau"
+    },
+    {
+      "name": "epsstd",
+      "text": "epsstd"
+    },
+    {
+      "name": "interest_",
+      "text": "interest_"
+    }
+  ],
+  "al_info": null,
+  "variables": [
+    {
+      "name": "cons_h",
+      "text": "cons_h"
+    },
+    {
+      "name": "i_dep",
+      "text": "i_dep"
+    },
+    {
+      "name": "infl",
+      "text": "infl"
+    },
+    {
+      "name": "omeg_t",
+      "text": "omeg_t"
+    },
+    {
+      "name": "s_t",
+      "text": "s_t"
+    },
+    {
+      "name": "chi_t",
+      "text": "chi_t"
+    },
+    {
+      "name": "thet1_t",
+      "text": "thet1_t"
+    },
+    {
+      "name": "thet2_t",
+      "text": "thet2_t"
+    },
+    {
+      "name": "y_t",
+      "text": "y_t"
+    },
+    {
+      "name": "spread",
+      "text": "spread"
+    },
+    {
+      "name": "q_t",
+      "text": "q_t"
+    },
+    {
+      "name": "inflation",
+      "text": "inflation"
+    },
+    {
+      "name": "inflationq",
+      "text": "inflationq"
+    },
+    {
+      "name": "interest",
+      "text": "interest"
+    },
+    {
+      "name": "ygap",
+      "text": "ygap"
+    },
+    {
+      "name": "cons_e",
+      "text": "cons_e"
+    },
+    {
+      "name": "mon_cost",
+      "text": "mon_cost"
+    },
+    {
+      "name": "Bankrupt",
+      "text": "Bankrupt"
+    },
+    {
+      "name": "output",
+      "text": "output"
+    },
+    {
+      "name": "outputgap",
+      "text": "outputgap"
+    },
+    {
+      "name": "fo_t",
+      "text": "fo_t"
+    },
+    {
+      "name": "ho_t",
+      "text": "ho_t"
+    },
+    {
+      "name": "i_l",
+      "text": "i_l"
+    },
+    {
+      "name": "credit",
+      "text": "credit"
+    },
+    {
+      "name": "stdoi_t",
+      "text": "stdoi_t"
+    },
+    {
+      "name": "Util",
+      "text": "Util"
+    },
+    {
+      "name": "Welf",
+      "text": "Welf"
+    },
+    {
+      "name": "i_e",
+      "text": "i_e"
+    },
+    {
+      "name": "y_e",
+      "text": "y_e"
+    },
+    {
+      "name": "a_t",
+      "text": "a_t"
+    },
+    {
+      "name": "mu_t",
+      "text": "mu_t"
+    },
+    {
+      "name": "tau_t",
+      "text": "tau_t"
+    }
+  ]
+}

--- a/static/mmci-cli/models/NK_DT12/NK_DT12.mod
+++ b/static/mmci-cli/models/NK_DT12/NK_DT12.mod
@@ -1,0 +1,243 @@
+// NK_DT12
+// Based on De Fiore & Tristani (2012)
+// With coefficients a' la Woodford
+
+// implemented by Christian Muecke and Johannes Binder
+// code based on authors code, '%' comments are ours
+
+// Endogenous variables
+var cons_h, i_dep, infl, omeg_t, s_t, chi_t, thet1_t, thet2_t, 
+y_t, spread, q_t, ygap, cons_e, mon_cost, Bankrupt, fo_t, ho_t,  i_l, credit, stdoi_t, %% deleted fo_prime
+Util, Welf,
+i_e, y_e, a_t, mu_t, tau_t
+
+//**************************************************************************
+// Modelbase Variables                                                   //*
+        interest inflation inflationq outputgap output                   //*
+        //fispol                                                         //*   
+        ;                                                                //*
+//**************************************************************************
+
+
+// Disturbances;
+varexo epsA, epsmu,epstau,epsstd 				// ,epspol
+
+//**************************************************************************
+// Modelbase Shocks                                                      //*       
+       interest_                                                         //*
+       //fiscal_                                                           //*   
+       ;                                                                 //*
+//**************************************************************************
+
+
+//PARAMETERS
+parameters 
+
+//************************************************************************** 
+// Modelbase Parameters                                                  //*
+                                                                         //*
+        cofintintb1 cofintintb2 cofintintb3 cofintintb4                  //*
+        cofintinf0 cofintinfb1 cofintinfb2 cofintinfb3 cofintinfb4       //*
+        cofintinff1 cofintinff2 cofintinff3 cofintinff4                  //*
+        cofintout cofintoutb1 cofintoutb2 cofintoutb3 cofintoutb4        //*
+        cofintoutf1 cofintoutf2 cofintoutf3 cofintoutf4                  //*
+        cofintoutp cofintoutpb1 cofintoutpb2 cofintoutpb3 cofintoutpb4   //*
+        cofintoutpf1 cofintoutpf2 cofintoutpf3 cofintoutpf4              //*
+        std_r_ std_r_quart coffispol                                    //*
+                                                                         //*
+//**************************************************************************
+
+psai, phi, sig, mu_hat, bet, rho_mu, epsil, thet, Omega1, 
+mu_oi, std_oi, rho_a, tau, nbeta, zet_hous, rho_pol, y_t_ss, y_e_ss; 		// poly, zet, zet_gap, rhoint,
+
+
+
+// Calibrated parameter values
+phi = 0.11;
+psai = 1.35;  % scaling disutility of labor 
+sig = 0.16 ; % risk aversion
+
+epsil = 11.0 ; % elasticity of substitution across goods
+thet = .66 ; % probability of not adjusting prices  
+mu_hat = 0.12 ; % WAS ==>> 0.15 <<== SS financial mark-up  
+bet = .99 ; % discount factor
+rho_mu = .7317 ; % persistence of financial shocks: as in the endogenous case
+% rho_pol = 0.5 ; % persistence of policy shocks
+rho_a = 0.9 ; % persistence of tech shocks
+
+tau = 0.046 ;  % DT case with entr. cons, Woodford parameters
+gam = .08 ;
+
+mu_oi = 1.0 ;
+std_oi = 0.073 ; %   DT case with entr. cons, Woodford parameters
+
+% zet_hous = 1/(1 + cons_h^(-sig)) ;     
+zet_hous = 1/(1 + 0.309669908^(-sig)) ;  % DT case
+
+% Omega1 = chi_t*q_t
+Omega1 = epsil/(epsil-1)*1.02215437 ;     % DT case with entr. cons, Woodford parameters
+
+nbeta = bet;
+
+//**************************************************************************
+// Specification of Modelbase Parameters                                 //*
+                                                                         //*
+// Load Modelbase Monetary Policy Parameters                             //*
+thispath = pwd;                                                           
+cd('..');                                                                
+load policy_param.mat;                                                   
+for i=1:33                                                               
+    deep_parameter_name = M_.param_names(i,:);                           
+    eval(['M_.params(i)  = ' deep_parameter_name ' ;'])                  
+end                                                                      
+cd(thispath);                                                            
+                                                                         
+//**************************************************************************
+
+%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%% MODEL EQUATIONS %%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%
+
+model;        
+
+//**************************************************************************
+// Definition of Modelbase Variables in Terms of Original Model Variables //*
+
+interest   = 4*(i_dep-steady_state(i_dep));                               //*         
+inflation  = infl+infl(-1)+infl(-2)+infl(-3) - 4*steady_state(infl);      //*       
+inflationq = 4*(infl-steady_state(infl));                                 //*     
+outputgap  = ygap;                                                        //*
+output     =  y_t-steady_state(y_t) ;                                     //*  
+				                                                          //*    
+//**************************************************************************
+
+
+//**************************************************************************                                                                    
+// Policy Rule                                                           //*
+                                                                         //*
+// Monetary Policy                                                       //*
+                                                                         //*
+interest =   cofintintb1*interest(-1)                                    //* 
+           + cofintintb2*interest(-2)                                    //* 
+           + cofintintb3*interest(-3)                                    //* 
+           + cofintintb4*interest(-4)                                    //* 
+           + cofintinf0*inflationq                                       //* 
+           + cofintinfb1*inflationq(-1)                                  //* 
+           + cofintinfb2*inflationq(-2)                                  //* 
+           + cofintinfb3*inflationq(-3)                                  //* 
+           + cofintinfb4*inflationq(-4)                                  //* 
+           + cofintinff1*inflationq(+1)                                  //* 
+           + cofintinff2*inflationq(+2)                                  //* 
+           + cofintinff3*inflationq(+3)                                  //* 
+           + cofintinff4*inflationq(+4)                                  //* 
+           + cofintout*outputgap 	                                     //* 
+           + cofintoutb1*outputgap(-1)                                   //* 
+           + cofintoutb2*outputgap(-2)                                   //* 
+           + cofintoutb3*outputgap(-3)                                   //* 
+           + cofintoutb4*outputgap(-4)                                   //* 
+           + cofintoutf1*outputgap(+1)                                   //* 
+           + cofintoutf2*outputgap(+2)                                   //* 
+           + cofintoutf3*outputgap(+3)                                   //* 
+           + cofintoutf4*outputgap(+4)                                   //*
+           + cofintoutp*output 	                                         //* 
+           + cofintoutpb1*output(-1)                                     //* 
+           + cofintoutpb2*output(-2)                                     //* 
+           + cofintoutpb3*output(-3)                                     //* 
+           + cofintoutpb4*output(-4)                                     //* 
+           + cofintoutpf1*output(+1)                                     //* 
+           + cofintoutpf2*output(+2)                                     //* 
+           + cofintoutpf3*output(+3)                                     //* 
+           + cofintoutpf4*output(+4)                                     //*  
+           + std_r_ *interest_;                                         //* 
+                                                                         //*
+// Discretionary Government Spending                                     //*
+                                                                         //*
+//  fispol = coffispol*fiscal_;                                          //*  
+//**************************************************************************
+
+// Original Model Code:
+
+// Welfare
+exp(Util) = zet_hous*(exp(cons_h)^(1-sig)/(1-sig) - psai/(1+phi)*(exp(s_t)*exp(y_t)/exp(a_t))^(1+phi))+
+     (1-zet_hous)*exp(cons_e) ;   
+exp(Welf) = exp(Util) + nbeta*exp(Welf(+1));
+
+// Actual economy
+%% EQ: (9) using feasability of contract
+- exp(spread) + exp(omeg_t)/(1 - exp(mu_t)*exp(Bankrupt) - exp(fo_t));
+%% Appendix EQ (5) using EQ (5)
+- psai*exp(cons_h)^sig*exp(s_t)^phi*exp(y_t)^phi + exp(a_t)^(1+phi)*Omega1/exp(q_t)/exp(chi_t) ; 
+
+- exp(chi_t)*exp(i_dep)*exp(tau_t)*exp(a_t)^0 + exp(s_t)*exp(y_t)*exp(fo_t)*(1+exp(mu_t)*exp(ho_t)/( 
+        - (1-erf((log(exp(omeg_t))-log(mu_oi))/sqrt(2)/exp(stdoi_t)))/2    )) ;  %replaced fo_prime
+%% EQ: (7)  %replaced fo_prime        
+- exp(q_t) + exp(i_dep)/(1 - exp(mu_t)*exp(Bankrupt) + exp(mu_t)*exp(fo_t)*exp(ho_t)/( 
+        - (1-erf((log(exp(omeg_t))-log(mu_oi))/sqrt(2)/exp(stdoi_t)))/2    )) ;  
+
+%% Distributions
+- exp(Bankrupt) + (1+erf((log(exp(omeg_t))-log(mu_oi))/sqrt(2)/exp(stdoi_t)))/2 ;
+
+- exp(fo_t) + (exp(log(mu_oi)+exp(stdoi_t)^2/2)/2*(1+erf((log(mu_oi)+exp(stdoi_t)^2-log(exp(omeg_t)))/sqrt(2)/exp(stdoi_t)))
+    - exp(omeg_t)/2*(1-erf((log(exp(omeg_t))-log(mu_oi))/sqrt(2)/exp(stdoi_t)))) ;
+
+- exp(ho_t) + 1/exp(omeg_t)*normpdf(omeg_t,log(mu_oi),exp(stdoi_t));
+
+%%-  exp(fo_prime) - (1-erf((log(exp(omeg_t))-log(mu_oi))/sqrt(2)/exp(stdoi_t)))/2 ;
+%%
+
+%% Appendix: EQ (1)
+- exp(cons_h) + exp(y_t)*(1 - exp(fo_t)*exp(s_t)/exp(chi_t)) ;		
+%% Appendix: EQ (6)
+- 1/exp(i_dep) + bet*exp(cons_h(+1))^(-sig)/(exp(cons_h)^(-sig))/exp(infl(+1)) ;	
+%% Appendix: EQ (7)
+- 1 + thet*exp(infl)^(epsil-1) + (1-thet)*(epsil/(epsil-1)*exp(thet1_t)/exp(thet2_t))^(1-epsil) ;	
+%% Appendix: EQ (8)
+- exp(thet1_t) + exp(y_t)/exp(chi_t) + thet*bet*exp(infl(+1))^(epsil-1)*exp(cons_h(+1))^(-sig)/(exp(cons_h)^(-sig))*exp(thet1_t(+1)) ;		
+%% Appendix: EQ (9)
+- exp(thet2_t) + exp(y_t) + thet*bet*exp(infl(+1))^(epsil-2)*exp(cons_h(+1))^(-sig)/(exp(cons_h)^(-sig))*exp(thet2_t(+1)) ;			
+%% Appendix: EQ (10)
+- exp(s_t) + (1-thet)*((1-thet*exp(infl)^(epsil-1))/(1-thet))^(-epsil/(1-epsil)) + thet*exp(infl)^epsil*exp(s_t(-1)) ;		
+%% Output gap as defined on p.914
+- exp(ygap) + exp(y_t-y_e-y_t_ss+(y_e_ss)); 		
+
+- exp(cons_e) + exp(y_t) - exp(cons_h);
+
+- exp(mon_cost) + exp(mu_t)*exp(Bankrupt);
+
+- exp(i_l) + exp(i_dep)*exp(spread);
+%% x_t-tau_t using EQ (8)
+- exp(credit) + exp(tau_t)*exp(a_t)^0*exp(q_t)*(1 - exp(mu_t)*exp(Bankrupt) - exp(fo_t))/(exp(i_dep) - exp(q_t)*(1 - exp(mu_t)*exp(Bankrupt) - exp(fo_t)));		
+
+%// Original Monetary Policy Rule
+%// - exp(i_dep) + poly + (1/bet*exp(infl)^zet*exp(ygap)^zet_gap)^(1-rhoint) * (exp(i_dep(-1)))^rhoint * exp(interest_1);
+
+// Exogenous Shocks 
+- psai*exp(y_e)^(sig+phi) + exp(a_t)^(1+phi)/(epsil/(epsil-1))*Omega1 ;
+
+1/exp(i_e)-bet*exp(y_e(+1))^(-sig)/(exp(y_e)^(-sig)) ;
+
+mu_t-(1-rho_mu)*log(mu_hat)-rho_mu*mu_t(-1)-epsmu ;
+
+tau_t-(1-rho_mu)*log(tau)-rho_mu*tau_t(-1)-epstau ;
+
+stdoi_t-(1-rho_mu)*log(std_oi)-rho_mu*stdoi_t(-1)-epsstd ;
+
+a_t-rho_a*a_t(-1)-epsA;
+
+% interest_1-rho_pol*interest_1(-1)-interest_;
+
+end;
+
+steady;
+%check;
+
+shocks;
+var epsA; stderr 1.0 ; // in percentage terms
+var epstau; stderr 1.0; 
+var interest_; stderr 0; // in percentage terms % previously: var interest_; stderr 0.25; 
+var epsstd; stderr 0.6;
+end;
+
+% stoch_simul(order=1,irf=12, irf_shocks = (epsA, interest_)) infl ygap i_dep spread credit cons_h q_t chi_t tau_t a_t interest_1 stdoi_t  Bankrupt cons_e omeg_t s_t y_t y_e; 
+
+

--- a/static/mmci-cli/models/US_CCF12/US_CCF12.json
+++ b/static/mmci-cli/models/US_CCF12/US_CCF12.json
@@ -1,0 +1,475 @@
+{
+  "$schema": "model",
+  "name": "US_CCF12",
+  "capabilities": {
+    "fiscal_shock": true,
+    "inflation": true,
+    "interest": true,
+    "mp_shock": true,
+    "output": true,
+    "outputgap": true,
+    "rules": [
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11
+    ],
+    "unconditional_variances": true
+  },
+  "description": {
+    "ac_ref": "Chen et al. (2012)",
+    "paper_title": "The Macroeconomic Effects of Large-scale Asset Purchase Programmes",
+    "journal": "The Economics Journal 122(November), pp. F289-F315",
+    "replicants_name": "A. Taenzer",
+    "pub_date": "2012",
+    "keywords": [],
+    "description": "",
+    "category": "Estimated US model",
+    "authors": [
+      "Chen, Han",
+      "Cúrdia, Vasco",
+      "Ferrero, Andrea"
+    ]
+  },
+  "msr": null,
+  "variabledim": 1,
+  "al": false,
+  "shocks": [
+    {
+      "name": "eps_z",
+      "text": "eps_z"
+    },
+    {
+      "name": "eps_phi",
+      "text": "eps_phi"
+    },
+    {
+      "name": "eps_lambda",
+      "text": "eps_lambda"
+    },
+    {
+      "name": "eps_mu",
+      "text": "eps_mu"
+    },
+    {
+      "name": "eps_zeta",
+      "text": "eps_zeta"
+    },
+    {
+      "name": "eps_bu",
+      "text": "eps_bu"
+    },
+    {
+      "name": "eps_br",
+      "text": "eps_br"
+    },
+    {
+      "name": "eps_T",
+      "text": "eps_T"
+    },
+    {
+      "name": "eps_B",
+      "text": "eps_B"
+    },            
+    {
+      "name": "fiscal_",
+      "text": "fiscal_"
+    },
+    {
+      "name": "interest_",
+      "text": "interest_"
+    }
+  ],
+  "al_info": null,
+  "variables": [
+    {
+      "name": "marc",
+      "text": "marc"
+    },
+    {
+      "name": "rk",
+      "text": "rk"
+    },
+    {
+      "name": "r",
+      "text": "r"
+    },
+    {
+      "name": "rL",
+      "text": "rL"
+    },
+    {
+      "name": "wz",
+      "text": "wz"
+    },
+    {
+      "name": "Kz",
+      "text": "Kz"
+    },
+    {
+      "name": "Kz_eff",
+      "text": "Kz_eff"
+    },
+    {
+      "name": "L",
+      "text": "L"
+    },
+    {
+      "name": "Yz",
+      "text": "Yz"
+    },
+    {
+      "name": "Xpnu",
+      "text": "Xpnu"
+    },
+    {
+      "name": "Xpnr",
+      "text": "Xpnr"
+    },
+    {
+      "name": "Xpdu",
+      "text": "Xpdu"
+    },
+    {
+      "name": "Xpdr",
+      "text": "Xpdr"
+    },
+    {
+      "name": "Xwnu",
+      "text": "Xwnu"
+    },
+    {
+      "name": "Xwnr",
+      "text": "Xwnr"
+    },
+    {
+      "name": "Xwdu",
+      "text": "Xwdu"
+    },
+    {
+      "name": "Xwdr",
+      "text": "Xwdr"
+    },
+    {
+      "name": "pi",
+      "text": "pi"
+    },
+    {
+      "name": "fispol",
+      "text": "fispol"
+    },
+    {
+      "name": "u",
+      "text": "u"
+    },
+    {
+      "name": "Iz",
+      "text": "Iz"
+    },
+    {
+      "name": "inflation",
+      "text": "inflation"
+    },
+    {
+      "name": "inflationq",
+      "text": "inflationq"
+    },
+    {
+      "name": "interest",
+      "text": "interest"
+    },
+    {
+      "name": "mu",
+      "text": "mu"
+    },
+    {
+      "name": "z",
+      "text": "z"
+    },
+    {
+      "name": "psi",
+      "text": "psi"
+    },
+    {
+      "name": "lambda_ms",
+      "text": "lambda_ms"
+    },
+    {
+      "name": "bu",
+      "text": "bu"
+    },
+    {
+      "name": "br",
+      "text": "br"
+    },
+    {
+      "name": "Xiu",
+      "text": "Xiu"
+    },
+    {
+      "name": "Xir",
+      "text": "Xir"
+    },
+    {
+      "name": "q",
+      "text": "q"
+    },
+    {
+      "name": "Czu",
+      "text": "Czu"
+    },
+    {
+      "name": "Czr",
+      "text": "Czr"
+    },
+    {
+      "name": "zeta_h",
+      "text": "zeta_h"
+    },
+    {
+      "name": "output",
+      "text": "output"
+    },
+    {
+      "name": "outputgap",
+      "text": "outputgap"
+    },
+    {
+      "name": "Bz",
+      "text": "Bz"
+    },
+    {
+      "name": "BzL",
+      "text": "BzL"
+    },
+    {
+      "name": "Gz",
+      "text": "Gz"
+    },
+    {
+      "name": "Tz",
+      "text": "Tz"
+    },
+    {
+      "name": "shock_zeta",
+      "text": "shock_zeta"
+    },
+    {
+      "name": "BLMVz",
+      "text": "BLMVz"
+    },
+    {
+      "name": "BTotMVz",
+      "text": "BTotMVz"
+    },
+    {
+      "name": "slope",
+      "text": "slope"
+    },
+    {
+      "name": "rLEH",
+      "text": "rLEH"
+    },
+    {
+      "name": "RP",
+      "text": "RP"
+    },
+    {
+      "name": "rr",
+      "text": "rr"
+    },
+    {
+      "name": "rLr",
+      "text": "rLr"
+    },
+    {
+      "name": "rLEHr",
+      "text": "rLEHr"
+    },
+    {
+      "name": "Yz_growth",
+      "text": "Yz_growth"
+    },
+    {
+      "name": "pi_ann",
+      "text": "pi_ann"
+    },
+    {
+      "name": "r_ann",
+      "text": "r_ann"
+    },
+    {
+      "name": "rL_ann",
+      "text": "rL_ann"
+    },
+    {
+      "name": "dy",
+      "text": "dy"
+    },
+    {
+      "name": "y",
+      "text": "y"
+    },
+    {
+      "name": "infl",
+      "text": "infl"
+    },
+    {
+      "name": "FFR",
+      "text": "FFR"
+    },
+    {
+      "name": "bondrate",
+      "text": "bondrate"
+    },
+    {
+      "name": "riskprem",
+      "text": "riskprem"
+    },
+    {
+      "name": "y_level",
+      "text": "y_level"
+    },
+    {
+      "name": "eps_Gz",
+      "text": "eps_Gz"
+    },
+    {
+      "name": "marcf",
+      "text": "marcf"
+    },
+    {
+      "name": "pif",
+      "text": "pif"
+    },    
+    {
+      "name": "rkf",
+      "text": "rkf"
+    },
+    {
+      "name": "rf",
+      "text": "rf"
+    },
+    {
+      "name": "rLf",
+      "text": "rLf"
+    },
+    {
+      "name": "wzf",
+      "text": "wzf"
+    },
+    {
+      "name": "Kzf",
+      "text": "Kzf"
+    },
+    {
+      "name": "Kz_eff_f",
+      "text": "Kz_eff_f"
+    },
+    {
+      "name": "Lf",
+      "text": "Lf"
+    },
+    {
+      "name": "Xwnuf",
+      "text": "Xwnuf"
+    },
+    {
+      "name": "Xwnrf",
+      "text": "Xwnrf"
+    },
+    {
+      "name": "Xwduf",
+      "text": "Xwduf"
+    },
+    {
+      "name": "Xwdrf",
+      "text": "Xwdrf"
+    },
+    {
+      "name": "uf",
+      "text": "uf"
+    },
+    {
+      "name": "Izf",
+      "text": "Izf"
+    },
+    {
+      "name": "muf",
+      "text": "muf"
+    },
+    {
+      "name": "zf",
+      "text": "zf"
+    },
+    {
+      "name": "psif",
+      "text": "psif"
+    },
+    {
+      "name": "buf",
+      "text": "buf"
+    },
+    {
+      "name": "brf",
+      "text": "brf"
+    },
+    {
+      "name": "Xiuf",
+      "text": "Xiuf"
+    },
+    {
+      "name": "Xirf",
+      "text": "Xirf"
+    },
+    {
+      "name": "Czuf",
+      "text": "Czuf"
+    },
+    {
+      "name": "Czrf",
+      "text": "Czrf"
+    },
+    {
+      "name": "zeta_h_f",
+      "text": "zeta_h_f"
+    },
+    {
+      "name": "Bzf",
+      "text": "Bzf"
+    },
+    {
+      "name": "BzLf",
+      "text": "BzLf"
+    },
+    {
+      "name": "Gzf",
+      "text": "Gzf"
+    },
+    {
+      "name": "Tzf",
+      "text": "Tzf"
+    },
+    {
+      "name": "BLMVzf",
+      "text": "BLMVzf"
+    },
+    {
+      "name": "BTotMVzf",
+      "text": "BTotMVzf"
+    },
+    {
+      "name": "qf",
+      "text": "qf"
+    },
+    {
+      "name": "ygap",
+      "text": "ygap"
+    }  
+  ]
+}


### PR DESCRIPTION
NOTE: there are some problems to be resolved before merging, which I describe below!

NK_DEFK17: 
 -> msr omitted, since it includes steady-state levels
 -> also omitted rules CEE, Coenen, GR, LWW, SW as for those no steady state could be found
 -> otherwise fine

US_CCF12:
 -> msr omitted since it includes technology process
 -> for rules Taylor, OW08, Coenen gives error message "Reference to non-existent field 'AUTendo_names'"
 -> screenshot attached
![Error_US_CCF12](https://user-images.githubusercontent.com/34969113/67215908-948f5e80-f422-11e9-831b-fee13d8c30c0.png)

NK_DT12:
 -> msr omitted since it includes constant
 -> for all rules the error message "The steady state contains NaN or Inf" appears
 -> screenshot attached
![Error_NK_DT12](https://user-images.githubusercontent.com/34969113/67216444-842bb380-f423-11e9-9ea6-4d078cc0dacd.png)
