### PR TITLE
fix ghost shock/variable selection after using the "reload data" button

### DIFF
--- a/src/renderer/store/modules/models.js
+++ b/src/renderer/store/modules/models.js
@@ -89,6 +89,7 @@ const actions = {
       commit('setModels', models);
       commit('setErrors', errors);
       commit('options/setDefaultStates', models, { root: true });
+      commit('options/clearModels', null, { root: true });
 
       errors.forEach((err) => {
         window.vue.$bvToast.toast(`There was an error loading model ${err.model}:\n${err.message}`, {


### PR DESCRIPTION
The `reload data` button now clears all selections (models, shocks, rules, vars) to prevent selections being invalid (and thus invisible) after reload

fixes #79