### PR TITLE
Fix OCP workflow

### DIFF
--- a/.github/workflows/ocp.yml
+++ b/.github/workflows/ocp.yml
@@ -23,7 +23,7 @@ jobs:
       - id: list-models
         # thanks, https://code.dblock.org/2021/09/03/generating-task-matrix-by-looping-over-repo-files-with-github-actions.html
         # set xargs -n[NUM] to calculate more than 1 model per job, e.g. xargs -n5. cave: this will break caching!
-        run: echo "::set-output name=models::$(ls -l static/mmci-cli/models | awk '/^d/ {print $9}' | xargs -n1 | sed 's| |,|g' | jq -R -s -c 'split("\n")[:-1]')"
+        run: echo "models=$(ls -l static/mmci-cli/models | awk '/^d/ {print $9}' | xargs -n1 | sed 's| |,|g' | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
   simulate:
     needs:

--- a/.github/workflows/ocp.yml
+++ b/.github/workflows/ocp.yml
@@ -106,6 +106,7 @@ jobs:
       - uses: actions/download-artifact@v7
         with:
           path: dist/web/data
+          pattern: data-model-*
           merge-multiple: true
 
         # todo: switch to official pages action when it's prod ready (https://github.com/actions/deploy-pages)

--- a/.github/workflows/ocp.yml
+++ b/.github/workflows/ocp.yml
@@ -78,9 +78,9 @@ jobs:
 
       - if: github.ref == 'refs/heads/master'
         name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
-          name: data
+          name: data-model-${{ matrix.MODEL_NAMES }}
           path: static/mmci-cli/out/*.json
           overwrite: true
 
@@ -103,10 +103,10 @@ jobs:
       - run: npm i
       - run: npm run build:web
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
-          name: data
           path: dist/web/data
+          merge-multiple: true
 
         # todo: switch to official pages action when it's prod ready (https://github.com/actions/deploy-pages)
       - name: Deploy


### PR DESCRIPTION
actions/upload-artifact@v3 was defunct as of 2025 (see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

the workflow relied on artifacts being mutable which is no longer the case with recent versions of upload-artifact. simulation results are now uploaded to per model artifacts and merged during deployment.
